### PR TITLE
Remove leading backslash in jsonprune YT modifier

### DIFF
--- a/ads/ads.txt
+++ b/ads/ads.txt
@@ -10,7 +10,7 @@ youtube.com#@%#//scriptlet('set-constant', 'playerResponse.adPlacements', 'undef
 youtube.com#@%#//scriptlet('json-prune', 'playerResponse.adPlacements playerResponse.adSlots', 'playerResponse.streamingData.serverAbrStreamingUrl')
 youtube.com#@%#//scriptlet('json-prune-xhr-response', 'playerResponse.adPlacements playerResponse.playerAds playerResponse.adSlots adPlacements playerAds adSlots', '', '/playlist\?list=|\/player(?!.*(get_drm_license))|watch\?[tv]=|get_watch\?/')
 youtube.com#@%#//scriptlet('json-prune-fetch-response', 'playerResponse.adPlacements playerResponse.playerAds playerResponse.adSlots adPlacements playerAds adSlots', '', '/playlist\?list=|player\?|watch\?[tv]=|get_watch\?/')
-||youtube.com/youtubei/v1/player$jsonprune=\$['adPlacements'\, 'adSlots'\, 'playerAds']
+||youtube.com/youtubei/v1/player$jsonprune=$['adPlacements'\, 'adSlots'\, 'playerAds']
 
 ! Fixes infinite loading on YouTube; exception for a rule from AdGuard Base filter
 @@||googlevideo.com/videoplayback*ctier=L&*%2Cxpc%2Cctier%2C


### PR DESCRIPTION
## What does this PR do?
Removes a redundant backslash from the ads filter.