### PR TITLE
ads: add rules removing ads on embednow.top

### DIFF
--- a/ads/ads.txt
+++ b/ads/ads.txt
@@ -14,3 +14,7 @@ youtube.com#@%#//scriptlet('json-prune-fetch-response', 'playerResponse.adPlacem
 
 ! Fixes infinite loading on YouTube; exception for a rule from AdGuard Base filter
 @@||googlevideo.com/videoplayback*ctier=L&*%2Cxpc%2Cctier%2C
+
+||wowumounsou.com^$document
+||whauwhoatchee.com^
+embednow.top##div[style*="z-index: 2147483647"]:last-of-type


### PR DESCRIPTION
The embed can be found on https://f1live4.vercel.app/stream, under Sky Sports > [Embed] Sky Sports F1 HD.

Also available directly (link is likely to to get deactivated soon): https://embednow.top/embed/f1/2025/brazil/sprint

Regarding the rules themselves:
- `||wowumounsou.com^$document` blocks the popup domain
- `||whauwhoatchee.com^` blocks a request to an ad-specific JS script
- `embednow.top##div[style*="z-index: 2147483647"]:last-of-type` hides an overlay element that triggers a popup on click