### PR TITLE
no-doomscroll: add reddit list

### DIFF
--- a/no-doomscroll/reddit.txt
+++ b/no-doomscroll/reddit.txt
@@ -1,0 +1,7 @@
+# Feed on /, r/popular, r/explore and r/all
+reddit.com#?#:matches-path(/^\/(r\/popular\/|r\/all\/|explore\/)?$/) main#main-content
+reddit.com#?#:matches-path(/^\/(r\/popular\/|r\/all\/|explore\/)?$/) #subgrid-container
+
+# Recent posts
+reddit.com##recent-posts
+reddit.com##reddit-recent-pages


### PR DESCRIPTION
Hides:
- Content on home page
- Content on r/explore
- Content on r/popular
- Content on r/all
- Recent posts in sidebar
- Recent posts on all pages

Does not hide the left sidebar items such as Home, Popular, Explore, and All. I'm not sure it's possible to hide these individually since they live inside a shadow root. The only apparent solution is to hide the entire block with `reddit.com##left-nav-top-section` rule, but that would also hide "Start a community", which is not what we want.