### PR TITLE
no-doomscroll: fix single post view on LinkedIn

### DIFF
--- a/no-doomscroll/linkedin/main-zen.txt
+++ b/no-doomscroll/linkedin/main-zen.txt
@@ -8,7 +8,7 @@
 
 ! Feed
 linkedin.com##.feed-new-update-pill__new-update-button
-linkedin.com##.feed-shared-update-v2
+linkedin.com#?#:matches-path(/^\/feed\/?$/) .feed-shared-update-v2
 linkedin.com##.feed-shared-news-module
 linkedin.com##.feed-follows-module
 linkedin.com#?#:matches-path(/feed) div[data-view-tracking-scope*="FEED_UPDATE_SERVED"] > div:style(visibility: hidden !important)


### PR DESCRIPTION
The feed-shared-update-v2 class is also present on posts shown on individual pages. This change limits the rule to /feed only.