### PR TITLE
.github/workflows: add permissions and actions/checkout to purge-jsdelivr action

### DIFF
--- a/.github/workflows/purge-jsdelivr.yml
+++ b/.github/workflows/purge-jsdelivr.yml
@@ -8,10 +8,14 @@ on:
       - "no-doomscroll/**.txt"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   purge:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Purge jsDelivr cache
         run: |
           files=($(find no-doomscroll -type f -name '*.txt'))


### PR DESCRIPTION
Fixes the purge-jsDelivr action by adding actions/checkout step. Sets minimal permissions for additional security.

See the previously failed run: https://github.com/ZenPrivacy/filter-lists/actions/runs/21915398506/job/63281131629
