### PR TITLE
privacy: add rule to strip tracking param from copied Jira links

### DIFF
--- a/privacy/privacy.txt
+++ b/privacy/privacy.txt
@@ -6,5 +6,7 @@ reddit.com#%#//scriptlet('sanitize-clipboard', '/utm_.+/')
 linkedin.com#%#//scriptlet('sanitize-clipboard', '/utm_.+/ rcm')
 instagram.com#%#//scriptlet('sanitize-clipboard', '/utm_.+/ igsh')
 tiktok.com#%#//scriptlet('sanitize-clipboard', 'is_from_webapp sender_device web_id')
+atlassian.net#%#//scriptlet('sanitize-clipboard', 'atlOrigin')
+
 chatgpt.com#%#//scriptlet('prevent-fetch', 'ab.chatgpt.com/v1/rgstr method:POST')
 ||s-cdn.anthropic.com/images/*.gif?bk=


### PR DESCRIPTION
Add a sanitize-clipboard rule to remove the ?atlOrigin parameter from links copied on atlassian.net. This parameter appears when copying links from the Jira sharing dialog.

Also see https://github.com/DandelionSprout/adfilt/blob/66d5d99bbe9678803e29128cde21de5c767d7bce/LegitimateURLShortener.txt#L5023 and https://bugzilla.mozilla.org/show_bug.cgi?id=1921130.