### PR TITLE
no-doomscroll: hide shorts from search results

### DIFF
--- a/no-doomscroll/youtube/shorts-zen.txt
+++ b/no-doomscroll/youtube/shorts-zen.txt
@@ -17,6 +17,7 @@ www.youtube.com##ytd-rich-shelf-renderer[is-shorts]
 ! Video description, search results
 www.youtube.com##ytd-reel-shelf-renderer
 www.youtube.com##grid-shelf-view-model:has(ytm-shorts-lockup-view-model-v2)
+www.youtube.com##ytd-video-renderer:has(a[href^="/shorts/"])
 
 ! ## Mobile
 ! Home page feed


### PR DESCRIPTION
Add rule to hide shorts that masquerade as regular search results.

